### PR TITLE
feat(ui): implement theme switching and reveal animations for improved UX

### DIFF
--- a/web/components/Layout.tsx
+++ b/web/components/Layout.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from "react";
+import { ReactNode, useEffect } from "react";
 import { useRouter } from "next/router";
 import Navbar from "./Navbar";
 import Footer from "./Footer";
@@ -6,6 +6,34 @@ import Footer from "./Footer";
 export default function Layout({ children }: { children: ReactNode }) {
   const router = useRouter();
   const hideNavbar = router.pathname === "/";
+
+  useEffect(() => {
+    const root = document.documentElement;
+    const applyTheme = () => {
+      const stored = localStorage.getItem("theme");
+      if (stored === "light") {
+        root.classList.remove("dark");
+      } else if (stored === "dark") {
+        root.classList.add("dark");
+      } else if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
+        root.classList.add("dark");
+      } else {
+        root.classList.remove("dark");
+      }
+    };
+
+    applyTheme();
+
+    const media = window.matchMedia("(prefers-color-scheme: dark)");
+    const listener = () => {
+      if (!localStorage.getItem("theme")) {
+        applyTheme();
+      }
+    };
+    media.addEventListener("change", listener);
+    return () => media.removeEventListener("change", listener);
+  }, []);
+
   return (
     <div className="flex min-h-screen flex-col">
       {hideNavbar ? null : <Navbar />}


### PR DESCRIPTION
This pull request introduces several improvements to the theme handling and reveal animation logic on the landing page. The main changes include adding automatic theme management based on user preference and system settings, refining the reveal animation system to be more robust and accessible, and ensuring that decorative elements are excluded from reveal animations.

**Theme management improvements:**

* Added a `useEffect` in `Layout.tsx` to automatically apply light or dark theme based on local storage or system preferences, and to listen for system theme changes. (`web/components/Layout.tsx`)

**Reveal animation system enhancements:**

* Updated the reveal animation initialization to add a `.reveal-ready` class to the root element, filter out elements that should be ignored (such as those with `data-reveal-ignore` or certain tags), and only target visible elements for Intersection Observer. (`web/pages/index.tsx`) [[1]](diffhunk://#diff-24f1c21e9cead7a2a6d2c60c350f5eab687aac48ff32ecb6e03237512e306c87L484-R499) [[2]](diffhunk://#diff-24f1c21e9cead7a2a6d2c60c350f5eab687aac48ff32ecb6e03237512e306c87R508-R528) [[3]](diffhunk://#diff-24f1c21e9cead7a2a6d2c60c350f5eab687aac48ff32ecb6e03237512e306c87L505-R545)
* Marked animated gradient blob elements with `data-reveal-ignore` to prevent them from being included in reveal animations. (`web/pages/index.tsx`)

**CSS scoping and accessibility:**

* Scoped reveal animation CSS to only apply when `.reveal-ready` is present, improving accessibility and preventing unwanted transitions. (`web/pages/index.tsx`) [[1]](diffhunk://#diff-24f1c21e9cead7a2a6d2c60c350f5eab687aac48ff32ecb6e03237512e306c87L1110-R1158) [[2]](diffhunk://#diff-24f1c21e9cead7a2a6d2c60c350f5eab687aac48ff32ecb6e03237512e306c87L1122-R1180) [[3]](diffhunk://#diff-24f1c21e9cead7a2a6d2c60c350f5eab687aac48ff32ecb6e03237512e306c87L1183-R1231)